### PR TITLE
Use https target in Primo form.

### DIFF
--- a/ou-primo-search.tpl.php
+++ b/ou-primo-search.tpl.php
@@ -8,7 +8,7 @@
 ?>
 
 
-<form name="searchForm" role="search" method="get" action="http://ou-primo.hosted.exlibrisgroup.com/primo_library/libweb/action/dlSearch.do" enctype="application/x-www-form-urlencoded; charset=utf-8" id="simple" target="_self" class="searchPrimo">
+<form name="searchForm" role="search" method="get" action="https://ou-primo.hosted.exlibrisgroup.com/primo_library/libweb/action/dlSearch.do" enctype="application/x-www-form-urlencoded; charset=utf-8" id="simple" target="_self" class="searchPrimo">
     <input name="institution" value="OU" type="hidden">
     <input name="vid" value="OU" type="hidden">
     <input name="group" value="GUEST" type="hidden">
@@ -21,12 +21,12 @@
             <input class="form-control form-text" type="hidden" name="query" />
             <input class="form-control form-text" type="text" name="queryTemp" />
 			
-			<div style="text-align:right; float:right;"> <a href="http://ou-primo.hosted.exlibrisgroup.com/primo_library/libweb/action/search.do?mode=Advanced&ct=AdvancedSearch&scp.scps=scope%3A%28ou_dspace%29%2Cscope%3A%2801OKLA_NORMANLAW%29&dscnt=0&menuitem=0&vid=OU" Target="_blank">Discover Local (Catalog) </a></div>
+			<div style="text-align:right; float:right;"> <a href="https://ou-primo.hosted.exlibrisgroup.com/primo_library/libweb/action/search.do?mode=Advanced&ct=AdvancedSearch&scp.scps=scope%3A%28ou_dspace%29%2Cscope%3A%2801OKLA_NORMANLAW%29&dscnt=0&menuitem=0&vid=OU" Target="_blank">Discover Local (Catalog) </a></div>
 			
 			<div style="float:right; padding:0px 10px;" class="discover-border"> | </div>
 			
 			<div style="text-align:right; float:right;">
-			<a href="http://ou-primo.hosted.exlibrisgroup.com/primo_library/libweb/action/search.do?mode=Advanced&ct=AdvancedSearch&dscnt=0&menuitem=0&vid=OU" Target="_blank">Advanced Search </a> </div> 
+			<a href="https://ou-primo.hosted.exlibrisgroup.com/primo_library/libweb/action/search.do?mode=Advanced&ct=AdvancedSearch&dscnt=0&menuitem=0&vid=OU" Target="_blank">Advanced Search </a> </div> 
 			
         </div>
         <input name="search_scope" value="<?php print $search_scope; ?>" type="hidden">


### PR DESCRIPTION
Update OU Primo search form template to use HTTPS for primo searches and links. 

Motivation and Context
----------------------
encryption good! plain text bad!

How Has This Been Tested?
-------------------------
Verified working Primo search form and links on libraries.webdev
